### PR TITLE
Fixed byte overflow when inserting more than 128 of one item type

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.8
 
 # Mod Properties
-	mod_version = 0.0.2+mc1.19-fabric
+	mod_version = 0.0.3+mc1.19-fabric
 	maven_group = com.nibblepoker.expandedironbundles
 	archives_base_name = expanded-iron-bundles
 

--- a/src/main/java/com/nibblepoker/expandedironbundles/helpers/NbtHelpers.java
+++ b/src/main/java/com/nibblepoker/expandedironbundles/helpers/NbtHelpers.java
@@ -1,0 +1,70 @@
+package com.nibblepoker.expandedironbundles.helpers;
+
+import com.nibblepoker.expandedironbundles.ExpandedIronBundlesMod;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import static net.minecraft.item.ItemStack.EMPTY;
+
+public class NbtHelpers {
+	/**
+	 * Writes an item stack into a NBT compound using a TAG_Long instead of a TAG_Byte.
+	 * @param itemStack The item stack that should be inserted in the NBT compound.
+	 * @param nbt The NBT compound into which the item should be inserted.
+	 * @return The updated NBT compound
+	 */
+	public static NbtCompound writeLargeItemStackNbt(ItemStack itemStack, NbtCompound nbt) {
+		Identifier itemIdentifier = Registry.ITEM.getId(itemStack.getItem());
+		nbt.putString("id", itemIdentifier == null ? "minecraft:air" : itemIdentifier.toString());
+		nbt.putInt("Count", itemStack.getCount());
+		if (itemStack.getNbt() != null) {
+			nbt.put("tag", itemStack.getNbt().copy());
+		}
+		return nbt;
+	}
+	
+	public static ItemStack readLargeItemStackFromNbt(NbtCompound nbt) {
+		ItemStack returnedItemStack = EMPTY;
+		
+		try {
+			Item readItem = Registry.ITEM.get(new Identifier(nbt.getString("id")));
+			
+			// Will return the actual amount, or 0 if not found with that data type.
+			byte itemCountByte = nbt.getByte("Count");
+			int itemCountInt = nbt.getInt("Count");
+			
+			// Attempting to read vanilla/legacy byte variables
+			if (itemCountByte > 0) {
+				itemCountInt = itemCountByte;
+			} else if(itemCountByte < 0) {
+				// Fixing items that possibly went in the negatives.
+				itemCountInt = 256 - Math.abs((int) itemCountByte);
+			}
+			
+			// We can now assume that "itemCountInt" has the right stack size.
+			
+			// Preparing the ItemStack.
+			// This pretty much a copy of the "ItemStack(NbtCompound nbt)" constructor.
+			ItemStack itemStack = new ItemStack(readItem, itemCountInt);
+			
+			if (nbt.contains("tag", 10)) {
+				itemStack.setNbt(nbt.getCompound("tag"));
+				itemStack.getItem().postProcessNbt(itemStack.getNbt());
+			}
+			
+			if (itemStack.getItem().isDamageable()) {
+				itemStack.setDamage(itemStack.getDamage());
+			}
+			
+			returnedItemStack = itemStack;
+		} catch (RuntimeException err) {
+			ExpandedIronBundlesMod.LOGGER.debug("Tried to load invalid item: {}", nbt, err);
+			return EMPTY;
+		}
+		
+		return returnedItemStack;
+	}
+}

--- a/src/main/java/com/nibblepoker/expandedironbundles/items/CustomBundleItem.java
+++ b/src/main/java/com/nibblepoker/expandedironbundles/items/CustomBundleItem.java
@@ -102,6 +102,7 @@ public class CustomBundleItem extends BundleItem {
 		ItemStack targetItemStack = slot.getStack();
 		
 		if (targetItemStack.isEmpty()) {
+			// We remove an item from the bundle.
 			this.playRemoveOneSound(player);
 			removeFirstStack(stack).ifPresent((removedStack) -> {
 				addToBundle(
@@ -111,6 +112,7 @@ public class CustomBundleItem extends BundleItem {
 				);
 			});
 		} else if (targetItemStack.getItem().canBeNested()) {
+			// We attempt to add an item to the bundle.
 			int insertableItemCount = (this.maxOccupancy - getBundleOccupancy(stack)) / getItemOccupancy(targetItemStack);
 			
 			int itemAddedCount = addToBundle(
@@ -142,11 +144,13 @@ public class CustomBundleItem extends BundleItem {
 	public boolean onClicked(ItemStack stack, ItemStack otherStack, Slot slot, ClickType clickType, PlayerEntity player, StackReference cursorStackReference) {
 		if (clickType == ClickType.RIGHT && slot.canTakePartial(player)) {
 			if (otherStack.isEmpty()) {
+				// We remove an item from the bundle.
 				removeFirstStack(stack).ifPresent((itemStack) -> {
 					this.playRemoveOneSound(player);
 					cursorStackReference.set(itemStack);
 				});
 			} else {
+				// We attempt to add an item to the bundle.
 				int i = addToBundle(stack, otherStack, this.maxOccupancy);
 				if (i > 0) {
 					this.playInsertSound(player);
@@ -326,15 +330,20 @@ public class CustomBundleItem extends BundleItem {
 	 */
 	private static Optional<ItemStack> removeFirstStack(ItemStack stack) {
 		NbtCompound nbtCompound = stack.getOrCreateNbt();
+		
 		if (!nbtCompound.contains(NBT_ITEMS_KEY)) {
+			// No items were stored in the bundle
 			return Optional.empty();
 		} else {
 			NbtList nbtList = nbtCompound.getList(NBT_ITEMS_KEY, 10);
 			if (nbtList.isEmpty()) {
+				// No items were stored in the list, this shouldn't normally happen, probably...
 				return Optional.empty();
 			} else {
-				NbtCompound nbtCompound2 = nbtList.getCompound(0);
-				ItemStack itemStack = ItemStack.fromNbt(nbtCompound2);
+				NbtCompound extractedItemNbtCompound = nbtList.getCompound(0);
+				// ItemStack itemStack = ItemStack.fromNbt(extractedItemNbtCompound); //  TODO: Remove this line !
+				ItemStack itemStack = NbtHelpers.readLargeItemStackFromNbt(extractedItemNbtCompound);
+				
 				nbtList.remove(0);
 				if (nbtList.isEmpty()) {
 					stack.removeSubNbt(NBT_ITEMS_KEY);
@@ -363,7 +372,8 @@ public class CustomBundleItem extends BundleItem {
 				
 				for(int i = 0; i < bundleNbtItemList.size(); ++i) {
 					NbtCompound droppedItemNbtCompound = bundleNbtItemList.getCompound(i);
-					ItemStack itemStack = ItemStack.fromNbt(droppedItemNbtCompound);
+					//ItemStack itemStack = ItemStack.fromNbt(droppedItemNbtCompound);  //  TODO: Remove this line !
+					ItemStack itemStack = NbtHelpers.readLargeItemStackFromNbt(droppedItemNbtCompound);
 					player.dropItem(itemStack, true);
 				}
 			}

--- a/src/main/java/com/nibblepoker/expandedironbundles/items/CustomBundleItem.java
+++ b/src/main/java/com/nibblepoker/expandedironbundles/items/CustomBundleItem.java
@@ -228,7 +228,7 @@ public class CustomBundleItem extends BundleItem {
 				if (optional.isPresent()) {
 					// Grabbing the actual ItemStack from the NbtCompound, and removing it from the existing NBT list.
 					NbtCompound mergedItemStackNbtCompound = optional.get();
-					//ItemStack itemStack = ItemStack.fromNbt(mergedItemStackNbtCompound);
+					//ItemStack itemStack = ItemStack.fromNbt(mergedItemStackNbtCompound);  // TODO: Remove this line !
 					ItemStack itemStack = NbtHelpers.readLargeItemStackFromNbt(mergedItemStackNbtCompound);
 					nbtList.remove(mergedItemStackNbtCompound);
 					
@@ -236,17 +236,20 @@ public class CustomBundleItem extends BundleItem {
 					itemStack.increment(insertableItemCount);
 					
 					// Updating the NbtCompound read from the bundle.
-					//itemStack.writeNbt(mergedItemStackNbtCompound);
+					//itemStack.writeNbt(mergedItemStackNbtCompound);  // TODO: Remove this line !
 					NbtHelpers.writeLargeItemStackNbt(itemStack, mergedItemStackNbtCompound);
 					
 					// Adding back the NBT compound at the start of the list.
 					nbtList.add(0, mergedItemStackNbtCompound);
 				} else {
-					ItemStack itemStack2 = stack.copy();
-					itemStack2.setCount(insertableItemCount);
-					NbtCompound nbtCompound3 = new NbtCompound();
-					itemStack2.writeNbt(nbtCompound3);
-					nbtList.add(0, nbtCompound3);
+					// An existing stack for that item couldn't be found, so we make a copy to store in the bundle.
+					// The process is roughly the same as above.
+					ItemStack stackCopy = stack.copy();
+					stackCopy.setCount(insertableItemCount);
+					NbtCompound stackNbtCompound = new NbtCompound();
+					//stackCopy.writeNbt(nbtCompound3);  // TODO: Remove this line !
+					NbtHelpers.writeLargeItemStackNbt(stackCopy, stackNbtCompound);
+					nbtList.add(0, stackNbtCompound);
 				}
 			}
 			

--- a/src/main/java/com/nibblepoker/expandedironbundles/items/CustomBundleItem.java
+++ b/src/main/java/com/nibblepoker/expandedironbundles/items/CustomBundleItem.java
@@ -232,7 +232,6 @@ public class CustomBundleItem extends BundleItem {
 				if (optional.isPresent()) {
 					// Grabbing the actual ItemStack from the NbtCompound, and removing it from the existing NBT list.
 					NbtCompound mergedItemStackNbtCompound = optional.get();
-					//ItemStack itemStack = ItemStack.fromNbt(mergedItemStackNbtCompound);  // TODO: Remove this line !
 					ItemStack itemStack = NbtHelpers.readLargeItemStackFromNbt(mergedItemStackNbtCompound);
 					nbtList.remove(mergedItemStackNbtCompound);
 					
@@ -240,7 +239,6 @@ public class CustomBundleItem extends BundleItem {
 					itemStack.increment(insertableItemCount);
 					
 					// Updating the NbtCompound read from the bundle.
-					//itemStack.writeNbt(mergedItemStackNbtCompound);  // TODO: Remove this line !
 					NbtHelpers.writeLargeItemStackNbt(itemStack, mergedItemStackNbtCompound);
 					
 					// Adding back the NBT compound at the start of the list.
@@ -251,7 +249,6 @@ public class CustomBundleItem extends BundleItem {
 					ItemStack stackCopy = stack.copy();
 					stackCopy.setCount(insertableItemCount);
 					NbtCompound stackNbtCompound = new NbtCompound();
-					//stackCopy.writeNbt(nbtCompound3);  // TODO: Remove this line !
 					NbtHelpers.writeLargeItemStackNbt(stackCopy, stackNbtCompound);
 					nbtList.add(0, stackNbtCompound);
 				}
@@ -280,7 +277,6 @@ public class CustomBundleItem extends BundleItem {
 			Objects.requireNonNull(NbtCompound.class);
 			return nbtStream.map(NbtCompound.class::cast).filter((itemNbt) -> {
 				return ItemStack.canCombine(NbtHelpers.readLargeItemStackFromNbt(itemNbt), stack);
-				//return ItemStack.canCombine(ItemStack.fromNbt(itemNbt), stack);  //  TODO: Remove this line !
 			}).findFirst();
 		}
 	}
@@ -341,7 +337,6 @@ public class CustomBundleItem extends BundleItem {
 				return Optional.empty();
 			} else {
 				NbtCompound extractedItemNbtCompound = nbtList.getCompound(0);
-				// ItemStack itemStack = ItemStack.fromNbt(extractedItemNbtCompound); //  TODO: Remove this line !
 				ItemStack itemStack = NbtHelpers.readLargeItemStackFromNbt(extractedItemNbtCompound);
 				
 				nbtList.remove(0);
@@ -372,7 +367,6 @@ public class CustomBundleItem extends BundleItem {
 				
 				for(int i = 0; i < bundleNbtItemList.size(); ++i) {
 					NbtCompound droppedItemNbtCompound = bundleNbtItemList.getCompound(i);
-					//ItemStack itemStack = ItemStack.fromNbt(droppedItemNbtCompound);  //  TODO: Remove this line !
 					ItemStack itemStack = NbtHelpers.readLargeItemStackFromNbt(droppedItemNbtCompound);
 					player.dropItem(itemStack, true);
 				}
@@ -397,7 +391,6 @@ public class CustomBundleItem extends BundleItem {
 			NbtList nbtList = nbtCompound.getList(NBT_ITEMS_KEY, 10);
 			Stream<NbtElement> nbtStream = nbtList.stream();
 			Objects.requireNonNull(NbtCompound.class);
-			//return nbtStream.map(NbtCompound.class::cast).map(ItemStack::fromNbt);  //  TODO: Remove this line !
 			return nbtStream.map(NbtCompound.class::cast).map(NbtHelpers::readLargeItemStackFromNbt);
 		}
 	}

--- a/src/main/java/com/nibblepoker/expandedironbundles/items/CustomBundleItem.java
+++ b/src/main/java/com/nibblepoker/expandedironbundles/items/CustomBundleItem.java
@@ -262,20 +262,21 @@ public class CustomBundleItem extends BundleItem {
 	/**
 	 * Checks if a given item stack can be stacked with another item stack currently present in the given NBT list.
 	 * @param stack ???
-	 * @param items ???
+	 * @param itemsList ???
 	 * @return a NBT compound representing the item stack into which the given stack can be merged, if none are found,
 	 *   an empty NBT compound is returned.
 	 */
-	private static Optional<NbtCompound> canMergeStack(ItemStack stack, NbtList items) {
+	private static Optional<NbtCompound> canMergeStack(ItemStack stack, NbtList itemsList) {
 		if (stack.isOf(Items.BUNDLE)) {
 			return Optional.empty();
 		} else {
-			Stream<NbtElement> nbtStream = items.stream();
+			Stream<NbtElement> nbtStream = itemsList.stream();
 			Objects.requireNonNull(NbtCompound.class);
 			nbtStream = nbtStream.filter(NbtCompound.class::isInstance);
 			Objects.requireNonNull(NbtCompound.class);
-			return nbtStream.map(NbtCompound.class::cast).filter((item) -> {
-				return ItemStack.canCombine(ItemStack.fromNbt(item), stack);
+			return nbtStream.map(NbtCompound.class::cast).filter((itemNbt) -> {
+				return ItemStack.canCombine(NbtHelpers.readLargeItemStackFromNbt(itemNbt), stack);
+				//return ItemStack.canCombine(ItemStack.fromNbt(itemNbt), stack);  //  TODO: Remove this line !
 			}).findFirst();
 		}
 	}
@@ -386,7 +387,8 @@ public class CustomBundleItem extends BundleItem {
 			NbtList nbtList = nbtCompound.getList(NBT_ITEMS_KEY, 10);
 			Stream<NbtElement> nbtStream = nbtList.stream();
 			Objects.requireNonNull(NbtCompound.class);
-			return nbtStream.map(NbtCompound.class::cast).map(ItemStack::fromNbt);
+			//return nbtStream.map(NbtCompound.class::cast).map(ItemStack::fromNbt);  //  TODO: Remove this line !
+			return nbtStream.map(NbtCompound.class::cast).map(NbtHelpers::readLargeItemStackFromNbt);
 		}
 	}
 	

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "expandedironbundles",
-  "version": "0.0.2+mc1.19-fabric",
+  "version": "0.0.3+mc1.19-fabric",
 
   "name": "Expanded Iron Bundles",
   "description": "Provides bundles with more storage space, and new functionalities in the future.",


### PR DESCRIPTION
Fixed the issue described in #1.

Implemented a custom helper to interact with any NBT tag when an ItemStack need to be read or saved as a NBTCompound.

Some desync has been observed on server where if all the items in a bundle are thrown in one go and have more than a certain amount of a single item type, the client doesn't render the dropped item.
However they can be picked up and the server is aware they exist, unlike the client.